### PR TITLE
Make ttlmap thread safe

### DIFF
--- a/ttlmap.go
+++ b/ttlmap.go
@@ -185,6 +185,11 @@ func (m *TtlMap) expireElement(mapEl *mapElement) bool {
 	m.lock.Lock()
 	defer m.lock.Unlock()
 
+	// Ensure key hasn't already been removed by another thread
+	if _, exists := m.elements[mapEl.key]; !exists {
+		return false
+	}
+
 	if m.onExpire != nil {
 		m.onExpire(mapEl.key, mapEl.value)
 	}


### PR DESCRIPTION
Efficient add locks around Get/Set/Increment with a sync.RWMutex

All actions can now safely be performed concurrently. Concurrent Gets are now safe, regardless if the element expires or not. 

Fixes #2 